### PR TITLE
feat: Make exp. filter configurable.

### DIFF
--- a/ductus/tools/utils.py
+++ b/ductus/tools/utils.py
@@ -549,7 +549,7 @@ def create_json_update_fastq(sample_list, operation='add'):
     return {operation: list(map(lambda info: dict(zip(('sample', 'experiment', 'path'), info)), sample_list))}
 
 
-def filter_experiment(sample_sheet_file):
+def filter_experiment(sample_sheet_file, filter_out):
     """
         This function uses a path to a bioinformatic samples sheet and read it as a string to sort out the experiment name
         for the current run being processed. The file will be converted to a list to separate rows in
@@ -564,10 +564,6 @@ def filter_experiment(sample_sheet_file):
     with open(sample_sheet_file) as file:
         sample_sheet_list = file.readlines()
 
-    filter_out = [".*[Ll]ymphotrack.*",
-                  "DC",
-                  "AH",
-                  ]
     experiment_match = []
     for exp in filter_out:
         experiment_name = r'^[Ee]xperiment [Nn]ame,{}'.format(exp)

--- a/tests/samplesheets/files/SampleSheet.Archer.csv
+++ b/tests/samplesheets/files/SampleSheet.Archer.csv
@@ -1,0 +1,20 @@
+[Header]
+Local Run Manager Analysis Id,38038
+Experiment Name,260812_Archer Lymphom_LA8
+Date,Enter Date Here
+Module,GenerateFASTQ - 3.0.1
+Workflow,GenerateFASTQ
+Library Prep Kit,Custom
+Index Kit,Custom
+Description,Description
+Chemistry,Amplicon
+iemfileversion,4
+investigator name,BLS
+project name,Fusion Plex Lymphoma
+application,FASTQ Only 
+[Reads]
+151
+151
+[Settings]
+[Data]
+Sample_ID,Sample_Name,Description,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project

--- a/tests/samplesheets/test_tools_utils.py
+++ b/tests/samplesheets/test_tools_utils.py
@@ -1356,7 +1356,7 @@ class TestUtils(unittest.TestCase):
                            ".*[Aa]rcher.*",
                            ]
         self.assertFalse(filter_experiment(bioinfo_sample_sheet, filter_out_conf))
-                
+
         filter_out_conf_empty = []
         self.assertFalse(filter_experiment(bioinfo_sample_sheet, filter_out_conf_empty))
 

--- a/tests/samplesheets/test_tools_utils.py
+++ b/tests/samplesheets/test_tools_utils.py
@@ -1356,6 +1356,9 @@ class TestUtils(unittest.TestCase):
                            ".*[Aa]rcher.*",
                            ]
         self.assertFalse(filter_experiment(bioinfo_sample_sheet, filter_out_conf))
+                
+        filter_out_conf_empty = []
+        self.assertFalse(filter_experiment(bioinfo_sample_sheet, filter_out_conf_empty))
 
     def test_filter_experiment_true(self):
         bioinfo_sample_sheet = 'tests/samplesheets/files/SampleSheet.ah.csv'

--- a/tests/samplesheets/test_tools_utils.py
+++ b/tests/samplesheets/test_tools_utils.py
@@ -1350,15 +1350,39 @@ class TestUtils(unittest.TestCase):
 
     def test_filter_experiment_false(self):
         bioinfo_sample_sheet = 'tests/samplesheets/files/SampleSheet.te.csv'
-        self.assertFalse(filter_experiment(bioinfo_sample_sheet))
+        filter_out_conf = [".*[Ll]ymphotrack.*",
+                           "DC",
+                           "AH",
+                           ".*[Aa]rcher.*",
+                           ]
+        self.assertFalse(filter_experiment(bioinfo_sample_sheet, filter_out_conf))
 
     def test_filter_experiment_true(self):
         bioinfo_sample_sheet = 'tests/samplesheets/files/SampleSheet.ah.csv'
-        self.assertTrue(filter_experiment(bioinfo_sample_sheet))
+        filter_out_conf = [".*[Ll]ymphotrack.*",
+                           "DC",
+                           "AH",
+                           ".*[Aa]rcher.*",
+                           ]
+        self.assertTrue(filter_experiment(bioinfo_sample_sheet, filter_out_conf))
 
     def test_filter_lymphotrack(self):
         lympho_sample_sheet = 'tests/samplesheets/files/SampleSheet.lymphotrack.csv'
-        self.assertTrue(filter_experiment(lympho_sample_sheet))
+        filter_out_conf = [".*[Ll]ymphotrack.*",
+                           "DC",
+                           "AH",
+                           ".*[Aa]rcher.*",
+                           ]
+        self.assertTrue(filter_experiment(lympho_sample_sheet, filter_out_conf))
+
+    def test_filter_archer(self):
+        archer_sample_sheet = 'tests/samplesheets/files/SampleSheet.Archer.csv'
+        filter_out_conf = [".*[Ll]ymphotrack.*",
+                           "DC",
+                           "AH",
+                           ".*[Aa]rcher.*",
+                           ]
+        self.assertTrue(filter_experiment(archer_sample_sheet, filter_out_conf))
 
     def test_get_nr_expected_fastqs_lane(self):
         '''


### PR DESCRIPTION
Some experiment types should not be processed. The experiment is detected from the sample sheet and compared against a list with types to not be processed. If a type is in the list an informative e-mail will be sent to bioinformaticians about aborted processing. If not in the list and not one of our regular experiments the workflow will fail.

The list with experiments to be filter out in function filter_experiment is now provided as input instead of being hardcoded inside the function. This will make the list configurable.